### PR TITLE
Fix docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Then just visit it on your browser at `http://localhost:3000`
 
 ## Docker Image Note
 
-Currently this project is working with a self published image at `h4ck3rk3y/agentgpt`. If you have the `agentGPT` repo cloned locally, do the following instead from inside the `agentGPT` repository:
+Currently this project is working with a self published image at `h4ck3rk3y/agentgpt`. If you have the [`agentGPT`](https://github.com/reworkd/AgentGPT) repo cloned locally, do the following instead from inside the `agentGPT` repository:
 
 ```bash
-docker build -t IMAGE_NAME .
+./setup.sh --docker
 kurtosis run github.com/kurtosis-tech/agentgpt-package '{"OPENAI_API_KEY": "YOUR_API_KEY_HERE", "IMAGE": "IMAGE_NAME"}'
 ```
 


### PR DESCRIPTION
The current docker build instructions fail:

```
 => ERROR [6/6] RUN npm run build                                                                                                 0.7s
------
 > [6/6] RUN npm run build:
#11 0.354
#11 0.354 > agent-gpt@0.2.0 build
#11 0.354 > next build --no-lint
#11 0.354
#11 0.528 warn  - Linting is disabled
#11 0.670 ❌ Invalid environment variables:
#11 0.670  DATABASE_URL: Required
#11 0.670  NEXTAUTH_SECRET: Required
#11 0.670  NEXTAUTH_URL: Required
#11 0.670  OPENAI_API_KEY: Required
#11 0.670
#11 0.670 error - Failed to load next.config.mjs, see more info here https://nextjs.org/docs/messages/next-config-error
#11 0.674
#11 0.674 > Build error occurred
#11 0.675 Error: Invalid environment variables
#11 0.675     at file:///app/src/env/server.mjs:16:9
#11 0.675     at ModuleJob.run (node:internal/modules/esm/module_job:193:25)
------
executor failed running [/bin/sh -c npm run build]: exit code: 1
```